### PR TITLE
Various fixes for updated packages

### DIFF
--- a/autograd_linalg/__init__.py
+++ b/autograd_linalg/__init__.py
@@ -1,2 +1,2 @@
-from linalg import (solve_triangular, cholesky,
-                    solve_posdef_from_cholesky, inv_posdef_from_cholesky)
+from .linalg import (solve_triangular, cholesky,
+                     solve_posdef_from_cholesky, inv_posdef_from_cholesky)

--- a/autograd_linalg/linalg.py
+++ b/autograd_linalg/linalg.py
@@ -1,11 +1,13 @@
+from __future__ import absolute_import
+
 import numpy as np
 import autograd.numpy as anp
 from autograd.core import primitive
 from autograd.scipy.linalg import _flip
 from functools import partial
 
-import cython_linalg as cyla
-from util import T, symm, C
+from . import cython_linalg as cyla
+from .util import T, symm, C
 
 ### solve_triangular
 

--- a/autograd_linalg/util.py
+++ b/autograd_linalg/util.py
@@ -1,6 +1,6 @@
 import autograd.numpy as np
 import autograd.numpy.random as npr
-from autograd.util import check_grads
+from autograd.test_util import check_grads
 
 T = lambda x: np.swapaxes(x, -1, -2)
 symm = lambda x: (x + T(x)) / 2.


### PR DESCRIPTION
Allows the package to work with both Python 2 and 3. Also updates `linalg.py` to use the `defvjp` function in newer versions of autograd.